### PR TITLE
initialize track if applying PostStep processing

### DIFF
--- a/source/processes/biasing/generic/src/G4BiasingProcessInterface.cc
+++ b/source/processes/biasing/generic/src/G4BiasingProcessInterface.cc
@@ -490,6 +490,7 @@ G4VParticleChange* G4BiasingProcessInterface::PostStepDoIt(const G4Track& track,
 								  fFinalStateBiasingOperation, finalStateParticleChange );
 
 
+  fOccurenceBiasingParticleChange->Initialize(track);
   fOccurenceBiasingParticleChange->SetOccurenceWeightForInteraction( weightForInteraction );
   fOccurenceBiasingParticleChange->SetSecondaryWeightByProcess( true );
   fOccurenceBiasingParticleChange->SetWrappedParticleChange( finalStateParticleChange );


### PR DESCRIPTION
See https://github.com/LDMX-Software/geant4/issues/13 for full context.
This is not affecting much except the weird situation where we want to
biasing processes upstream of the target.

This resolves #13 .
